### PR TITLE
fixing highligts after comment blocks

### DIFF
--- a/grammars/velocity.cson
+++ b/grammars/velocity.cson
@@ -32,8 +32,8 @@
     'name': 'source.velocity.embedded'
   }
   {
-    'begin': '(?=#\\*)'
-    'end': '(?<=\\*#|\\*#\\n)'
+    'begin': '(=#\\*)'
+    'end': '(<=\\*#|\\*#\\n)'
     'name': 'source.velocity.embedded'
     'patterns': [
       {


### PR DESCRIPTION
When we have a comment block at the beginning of the code, the highlight stops.
